### PR TITLE
feat: enhance MCP tools and add CLI argument support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For remote cluster access through bastion hosts, you can use either SSH key (rec
    ssh -i ~/.ssh/id_rsa_bastion user@your-bastion-host.com
    ```
 
-4. **Configure MCP environment variables**:
+4. (optional) **Configure MCP environment variables**:
    ```bash
    export MCP_BASTION_HOST="your-bastion-host.com"
    export MCP_BASTION_USER="your-username"
@@ -93,7 +93,7 @@ For environments where SSH keys are not feasible:
    sudo yum install sshpass
    ```
 
-2. **Configure MCP environment variables**:
+2. (optional) **Configure MCP environment variables**:
    ```bash
    export MCP_BASTION_HOST="your-bastion-host.com"
    export MCP_BASTION_USER="your-username"
@@ -144,7 +144,43 @@ This script will:
 After successful setup, test the remote MCP server connection:
 
 ```bash
-node simple-remote-launcher.js
+node ./scripts/simple-remote-launcher.js
+```
+You may run the script using the following options:
+
+```bash
+Usage: simple-remote-launcher.js [options]
+
+Options:
+  -H, --host <host>           Bastion host address
+  -U, --user <user>           Bastion username  
+  -P, --password <password>   Bastion password (alternative to SSH key)
+  -p, --path <path>           Remote MCP server path
+  -s, --ssh-key <keyfile>     SSH private key file path
+  -k, --kubeconfig <config>   Remote kubeconfig file path
+  -e, --env <environment>     Node environment (default: production)
+  -h, --help                  Show this help message
+
+Environment Variables (used as defaults):
+  MCP_BASTION_HOST            Bastion host address
+  MCP_BASTION_USER            Bastion username
+  MCP_BASTION_PASSWORD        Bastion password
+  MCP_REMOTE_PATH             Remote MCP server path
+  MCP_SSH_KEY                 SSH private key file path
+  MCP_REMOTE_KUBECONFIG       Remote kubeconfig file path
+  MCP_REMOTE_NODE_ENV         Node environment
+
+Examples:
+  # Using CLI arguments only
+  ./scripts/simple-remote-launcher.js -H bastion.example.com -U root -s ~/.ssh/id_rsa -k /path/to/kubeconfig -p /opt/mcp-server
+
+  # Using environment variables (backward compatible)
+  export MCP_BASTION_HOST=bastion.example.com
+  ./scripts/simple-remote-launcher.js
+
+  # Mixed: CLI args override env vars
+  export MCP_BASTION_HOST=bastion.example.com
+  ./scripts/simple-remote-launcher.js -U admin -k /custom/kubeconfig
 ```
 
 This enhanced launcher will:

--- a/scripts/simple-remote-launcher.js
+++ b/scripts/simple-remote-launcher.js
@@ -3,22 +3,104 @@
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
 
-// MCP-Compatible Remote Launcher
-// Simplified for reliable MCP protocol communication
+// MCP-Compatible Remote Launcher with CLI Arguments Support
+// Supports both environment variables and command line arguments
+// CLI arguments take precedence over environment variables
 
-// Configuration with defaults
-const config = {
-  bastionHost: process.env.MCP_BASTION_HOST || 'bastion.company.com',
-  bastionUser: process.env.MCP_BASTION_USER || 'admin', 
-  bastionPassword: process.env.MCP_BASTION_PASSWORD || '',
-  remotePath: process.env.MCP_REMOTE_PATH || '/opt/openshift-mcp-server',
-  sshKey: process.env.MCP_SSH_KEY || '~/.ssh/id_rsa',
-  remoteKubeconfig: process.env.MCP_REMOTE_KUBECONFIG || '~/.kube/config',
-  remoteNodeEnv: process.env.MCP_REMOTE_NODE_ENV || 'production'
-};
+function parseArguments() {
+  const args = process.argv.slice(2);
+  const config = {
+    bastionHost: process.env.MCP_BASTION_HOST || 'bastion.company.com',
+    bastionUser: process.env.MCP_BASTION_USER || 'admin', 
+    bastionPassword: process.env.MCP_BASTION_PASSWORD || '',
+    remotePath: process.env.MCP_REMOTE_PATH || '/opt/openshift-mcp-server',
+    sshKey: process.env.MCP_SSH_KEY || '~/.ssh/id_rsa',
+    remoteKubeconfig: process.env.MCP_REMOTE_KUBECONFIG || '~/.kube/config',
+    remoteNodeEnv: process.env.MCP_REMOTE_NODE_ENV || 'production'
+  };
+
+  // Parse command line arguments (CLI args override env vars)
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '-H':
+      case '--host':
+        config.bastionHost = args[++i];
+        break;
+      case '-U':
+      case '--user':
+        config.bastionUser = args[++i];
+        break;
+      case '-P':
+      case '--password':
+        config.bastionPassword = args[++i];
+        break;
+      case '-p':
+      case '--path':
+        config.remotePath = args[++i];
+        break;
+      case '-s':
+      case '--ssh-key':
+        config.sshKey = args[++i];
+        break;
+      case '-k':
+      case '--kubeconfig':
+        config.remoteKubeconfig = args[++i];
+        break;
+      case '-e':
+      case '--env':
+        config.remoteNodeEnv = args[++i];
+        break;
+      case '-h':
+      case '--help':
+        printHelp();
+        process.exit(0);
+      default:
+        // Handle unknown arguments or pass them through if needed
+        break;
+    }
+  }
+  return config;
+}
+
+function printHelp() {
+  console.log(`
+Usage: simple-remote-launcher.js [options]
+
+Options:
+  -H, --host <host>           Bastion host address
+  -U, --user <user>           Bastion username  
+  -P, --password <password>   Bastion password (alternative to SSH key)
+  -p, --path <path>           Remote MCP server path
+  -s, --ssh-key <keyfile>     SSH private key file path
+  -k, --kubeconfig <config>   Remote kubeconfig file path
+  -e, --env <environment>     Node environment (default: production)
+  -h, --help                  Show this help message
+
+Environment Variables (used as defaults):
+  MCP_BASTION_HOST            Bastion host address
+  MCP_BASTION_USER            Bastion username
+  MCP_BASTION_PASSWORD        Bastion password
+  MCP_REMOTE_PATH             Remote MCP server path
+  MCP_SSH_KEY                 SSH private key file path
+  MCP_REMOTE_KUBECONFIG       Remote kubeconfig file path
+  MCP_REMOTE_NODE_ENV         Node environment
+
+Examples:
+  # Using CLI arguments only
+  simple-remote-launcher.js -H bastion.example.com -U root -s ~/.ssh/id_rsa -k /path/to/kubeconfig -p /opt/mcp-server
+
+  # Using environment variables (backward compatible)
+  MCP_BASTION_HOST=bastion.example.com simple-remote-launcher.js
+
+  # Mixed: CLI args override env vars
+  export MCP_BASTION_HOST=bastion.example.com
+  simple-remote-launcher.js -U admin -k /custom/kubeconfig
+  `);
+}
 
 // Quick validation (no logging to avoid MCP interference)
-function validateConfig() {
+function validateConfig(config) {
   const required = ['bastionHost', 'bastionUser', 'remotePath', 'remoteKubeconfig'];
   const missing = required.filter(key => !config[key] || config[key] === 'bastion.company.com');
   
@@ -35,8 +117,9 @@ function validateConfig() {
 // Main launcher function - simplified for MCP compatibility
 function launchMCPServer() {
   try {
+    const config = parseArguments();
     // Quick validation only
-    validateConfig();
+    validateConfig(config);
     
     // Build SSH command based on auth method
     const sshArgs = config.bastionPassword ? [
@@ -46,7 +129,7 @@ function launchMCPServer() {
       '-o', 'ServerAliveCountMax=3',
       '-o', 'LogLevel=ERROR',  // Suppress SSH noise
       `${config.bastionUser}@${config.bastionHost}`,
-      `cd '${config.remotePath}' && MCP_REMOTE_KUBECONFIG='${config.remoteKubeconfig}' NODE_ENV='${config.remoteNodeEnv}' exec node index.js`
+      `cd '${config.remotePath}' && MCP_REMOTE_KUBECONFIG='${config.remoteKubeconfig}' RUNNING_ON_BASTION=true NODE_ENV='${config.remoteNodeEnv}' exec node index.js`
     ] : [
       'ssh',
       '-i', config.sshKey,
@@ -55,7 +138,7 @@ function launchMCPServer() {
       '-o', 'ServerAliveCountMax=3',
       '-o', 'LogLevel=ERROR',  // Suppress SSH noise
       `${config.bastionUser}@${config.bastionHost}`,
-      `cd '${config.remotePath}' && MCP_REMOTE_KUBECONFIG='${config.remoteKubeconfig}' NODE_ENV='${config.remoteNodeEnv}' exec node index.js`
+      `cd '${config.remotePath}' && MCP_REMOTE_KUBECONFIG='${config.remoteKubeconfig}' RUNNING_ON_BASTION=true NODE_ENV='${config.remoteNodeEnv}' exec node index.js`
     ];
     
     // Launch immediately for MCP compatibility


### PR DESCRIPTION
- Add comprehensive CLI argument parsing to simple-remote-launcher.js
  - Support both environment variables and CLI args (-H, -U, -P, -p, -s, -k, -e, -h)
  - CLI arguments take precedence over env vars for flexible configuration
  - Built-in help system with examples and usage guide

- Improve journalctl pod error analysis functionality
  - Enhanced parameter handling and default value logic
  - Better remote access detection and SSH command building
  - Improved error reporting and debugging capabilities

- Enhance kubelet and CRI-O status checking
  - Multi-node support with per-node status reporting
  - Improved logging analysis and error detection
  - Better timeout handling and resource management

- Update README.md documentation
  - Accurate CLI argument reference matching implementation
  - Environment variable fallback documentation
  - Comprehensive examples for different usage scenarios

Assisted by: Cursor